### PR TITLE
refactor: remove reset effect

### DIFF
--- a/src/entities/vehicle/ui/VehicleForm/index.tsx
+++ b/src/entities/vehicle/ui/VehicleForm/index.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, ReactNode, useEffect, useState } from 'react';
+import { FC, memo, ReactNode, useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 
@@ -40,11 +40,6 @@ export const VehicleForm: FC<Props> = memo(
             setOpen(false);
             reset(defaultValues);
         };
-
-        useEffect(() => {
-            // update form after closing
-            !open && reset(defaultValues);
-        }, [open, defaultValues, reset]);
 
         return (
             <VehicleFormContext.Provider value={formInstance}>

--- a/src/features/AddVehicle/ui.tsx
+++ b/src/features/AddVehicle/ui.tsx
@@ -16,6 +16,7 @@ export const AddVehicle = () => {
         <>
             <VehicleForm
                 onSubmit={handleSubmit}
+                key="add"
                 uiOptions={{
                     formTitle: 'Add Vehicle',
                     trigger: <Button>Add Vehicle</Button>,

--- a/src/features/EditVehicle/ui.tsx
+++ b/src/features/EditVehicle/ui.tsx
@@ -29,6 +29,7 @@ export const EditVehicle: FC<Props> = ({ id }) => {
         <VehicleForm
             onSubmit={handleSubmit}
             defaultValues={defaultValues}
+            key={defaultValues?.id}
             uiOptions={{
                 formTitle: 'Edit Vehicle',
                 trigger: <Button outlined>Edit</Button>,


### PR DESCRIPTION
**how it works**: if a key is passed to a component, react will treat the same components as different, not sharing state between them => I can remove the effect which used to reset the form and skip some renders
**caveat**: state will be perceived for each individual edit and won't reset on close